### PR TITLE
Use relative paths in test config

### DIFF
--- a/testdata/complete/config.yaml
+++ b/testdata/complete/config.yaml
@@ -3,7 +3,7 @@ endpoints:
    - http://arangodb-local:8529
 username: root
 password: devroot
-migrationspath: /home/jdavenpo/go/src/github.com/deusdat/arangomigo/testdata/complete
+migrationspath: testdata/complete
 db: MigoFull
 extras:
   {patricksUser: jdavenpo,

--- a/testdata/updown/config.yaml
+++ b/testdata/updown/config.yaml
@@ -3,5 +3,5 @@ endpoints:
    - http://arangodb-local:8529
 username: root
 password: devroot
-migrationspath: /home/jdavenpo/go/src/github.com/deusdat/arangomigo/testdata/updown
+migrationspath: testdata/updown
 db: MigoMigrationExample


### PR DESCRIPTION
This commit replaces the absolute path (which included the authors home
directory name) in the test config with a relative path.
This allows the tests to be successfully run on other systems.