### PR TITLE
Call col.Name as a function

### DIFF
--- a/impls.go
+++ b/impls.go
@@ -282,7 +282,7 @@ func (cl Collection) migrate(ctx context.Context, db driver.Database, extras map
 			options.WaitForSync = cl.WaitForSync
 		}
 		err = col.SetProperties(ctx, options)
-		return errors.Wrapf(err, "Couldn't update collection '%s'", col.Name)
+		return errors.Wrapf(err, "Couldn't update collection '%s'", col.Name())
 	}
 
 	return nil


### PR DESCRIPTION
This is a small change to get the tests running. col.Name is a function
and without calling it, `go test` fails with the following error:

```sh
./impls.go:285: Wrapf format %s arg col.Name is a func value, not called
FAIL  github.com/deusdat/arangomigo [build failed]
```