### PR TITLE
Add the ability to skip SSL verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,9 @@ jobs:
     name: arangomigo
     runs-on: ubuntu-latest
     steps:
-      - name: Setup go 1.16
-        uses: actions/setup-go@v2
-        with: { go-version: '1.16' }
       - name: Checkout code
         uses: actions/checkout@v2
         with: { fetch-depth: 0 }
-
-      - name: Download dependencies
-        run: go mod download
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
@@ -27,8 +21,5 @@ jobs:
         continue-on-error: true
 
       - name: Test
-        run: |
-          docker run -d -p 1234:8529 -e ARANGO_ROOT_PASSWORD=simple arangodb/arangodb:3.7.2.1
-          sleep 10
-          go test ./...
+        run: ./test.sh
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.19
+
+WORKDIR /opt/
+
+RUN apt-get update && apt-get install -y wait-for-it
+
+COPY . .

--- a/Dockerfile.arangossl
+++ b/Dockerfile.arangossl
@@ -1,0 +1,12 @@
+FROM arangodb:latest
+
+RUN apk add openssl
+
+RUN openssl req -new -newkey rsa:4096 -nodes -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -keyout snakeoil.key -out snakeoil.csr
+RUN openssl x509 -req -sha256 -days 365 -in snakeoil.csr -signkey snakeoil.key -out snakeoil.pem
+RUN cat snakeoil.key snakeoil.pem > /etc/arangodb3/combined_snakeoil.pem
+
+RUN sed -i 's@endpoint = tcp://0.0.0.0:8529@endpoint = ssl://0.0.0.0:9258@' /etc/arangodb3/arangod.conf && \
+    echo "[ssl]" >> /etc/arangodb3/arangod.conf && \
+    echo "keyfile = /etc/arangodb3/combined_snakeoil.pem" >> /etc/arangodb3/arangod.conf
+

--- a/README.md
+++ b/README.md
@@ -335,3 +335,9 @@ name: SearchRecipes
 Instead of using the binary amd yaml files you can also embed the migrations directly from your go code. See 
 [perform_test.go](perform_test.go) for an example. 
 
+
+## Run tests
+
+To run tests inside Docker run:
+
+`./test.sh`

--- a/arangomigo.go
+++ b/arangomigo.go
@@ -6,9 +6,10 @@ package arangomigo
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	"log"
 )
 
 func TriggerMigration(configAt string) {
@@ -86,6 +87,7 @@ type Config struct {
 	Password       string
 	MigrationsPath StringArray
 	Db             string
+	SkipSslVerify  bool `yaml:"skip_ssl_verify"`
 	// Extras allows the user to pass in replaced variables
 	Extras map[string]interface{}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     - --
     - wait-for-it
     - -s
-    - --timeout=60
+    - --timeout=120
     - "arangodb_ssl:9258"
     - --
     - go
@@ -24,6 +24,7 @@ services:
       ARANGO_ROOT_PASSWORD: simple
   arangodb_ssl:
     build:
+      context: .
       dockerfile: Dockerfile.arangossl
     environment:
       ARANGO_ROOT_PASSWORD: simple

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,29 @@
 version: '3.7'
 services:
+  test:
+    build: .
+    command:
+    - wait-for-it
+    - -s
+    - "arangodb_db_container:8529"
+    - --
+    - wait-for-it
+    - -s
+    - --timeout=60
+    - "arangodb_ssl:9258"
+    - --
+    - go
+    - test
+    environment:
+    - ARANGO_URL=http://arangodb_db_container:8529
+    depends_on:
+    - arangodb_db_container
   arangodb_db_container:
     image: arangodb:latest
     environment:
       ARANGO_ROOT_PASSWORD: simple
-    ports:
-      - "8529:8529"
+  arangodb_ssl:
+    build:
+      dockerfile: Dockerfile.arangossl
+    environment:
+      ARANGO_ROOT_PASSWORD: simple

--- a/impls.go
+++ b/impls.go
@@ -3,6 +3,7 @@ package arangomigo
 import (
 	"context"
 	"crypto/md5"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 
@@ -181,6 +182,9 @@ func loadDb(
 func client(c Config) (driver.Client, error) {
 	conn, err := http.NewConnection(http.ConnectionConfig{
 		Endpoints: c.Endpoints,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: c.SkipSslVerify,
+		},
 	})
 
 	if e(err) {

--- a/perform_test.go
+++ b/perform_test.go
@@ -2,12 +2,22 @@ package arangomigo
 
 import (
 	"context"
+	"os"
 	"testing"
 )
 
+func GetEnv(key string, fallback string) string {
+	value, exists := os.LookupEnv(key)
+	if exists {
+		return value
+	}
+	return fallback
+}
+
 func TestPerform(t *testing.T) {
+	arangoUrl := GetEnv("ARANGO_URL", "http://0.0.0.0:8529")
 	config := Config{
-		Endpoints: []string{"http://0.0.0.0:8529"},
+		Endpoints: []string{arangoUrl},
 		Username:  "root",
 		Password:  "simple",
 		Db:        "MigoFullPerform",

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose up --build --exit-code-from=test

--- a/testdata/complete/config.yaml
+++ b/testdata/complete/config.yaml
@@ -1,6 +1,6 @@
 # Test configuration to make sure the system can create a complex db
 endpoints:
-   - http://0.0.0.0:8529
+   - http://arangodb_db_container:8529
 username: root
 password: simple
 migrationspath: testdata/complete

--- a/testdata/complete2/config.yaml
+++ b/testdata/complete2/config.yaml
@@ -1,6 +1,6 @@
 # Test configuration to make sure the system can create a complex db
 endpoints:
-   - http://0.0.0.0:8529
+   - http://arangodb_db_container:8529
 username: root
 password: simple
 migrationspath:

--- a/testdata/skip_ssl_verify/1.another.migration
+++ b/testdata/skip_ssl_verify/1.another.migration
@@ -1,0 +1,6 @@
+type: database
+action: create
+name: MigoFull2
+allowed:
+  - username: ${patricksUser}
+    password: ${patricksPassword}

--- a/testdata/skip_ssl_verify/config.yaml
+++ b/testdata/skip_ssl_verify/config.yaml
@@ -1,0 +1,9 @@
+# Test configuration to make sure the system can create a complex db
+endpoints:
+   - https://arangodb_ssl:9258
+skip_ssl_verify: true
+username: root
+password: simple
+migrationspath:
+   - testdata/skip_ssl_verify
+db: MigoFull2


### PR DESCRIPTION
This adds a key into the config that results in SSL connections not being verified.

To test this required creating an Arango instance with an invalid SSL certificate, so introduces another service into the `docker-compose.yml` file.

I've added the facility to run all the tests inside Docker, both locally and in CI. In the `perform_test.go` file it is easy to switch between a local and containerised Arango endpoint with an environment variable; in the tests using the YAML config file I've just had to change the values in there, which is of course controversial.

Let me know how you feel about these wider changes - I use the Remote Containers plugin in VSCode so this works really well for me, but I realise that it might not suit everyone.