### PR TITLE
feat: replace calls to fmt.Print with log.Print

### DIFF
--- a/arangomigo.go
+++ b/arangomigo.go
@@ -21,7 +21,7 @@ func TriggerMigration(configAt string) {
 	if err := migrate(*config); err != nil {
 		log.Fatal("Could not perform migration\n", err)
 	}
-	fmt.Println("Successfully completed migration")
+	log.Println("Successfully completed migration")
 }
 
 // TODO remember that having replayable migrations need to be possible too.

--- a/impls.go
+++ b/impls.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 
@@ -83,7 +84,7 @@ func migrateNow(
 	pms []PairedMigrations,
 	extras map[string]interface{},
 ) error {
-	fmt.Println("Starting migration now")
+	log.Println("Starting migration now")
 
 	mcol, err := db.Collection(ctx, migCol)
 	if e(err) {
@@ -150,7 +151,7 @@ func loadDb(
 		err = m.Migrate(ctx, db, extras)
 		if err == nil {
 			db = o.db
-			fmt.Printf("Target db is now %s\n", db.Name())
+			log.Printf("Target db is now %s\n", db.Name())
 		}
 	} else if err == nil {
 		m := (*pm)[0].change
@@ -169,7 +170,7 @@ func loadDb(
 			options := driver.CreateCollectionOptions{}
 			options.KeyOptions = &ko
 			if _, err := db.CreateCollection(ctx, migCol, &options); err != nil {
-				fmt.Printf("Failed to create collection %s", migCol)
+				log.Printf("Failed to create collection %s", migCol)
 				return db, err
 			}
 		}
@@ -291,7 +292,7 @@ func (cl Collection) Migrate(ctx context.Context, db driver.Database, _ map[stri
 		}
 		err = col.Remove(ctx)
 		if !e(err) {
-			fmt.Printf("Deleted collection '%s'\n", cl.Name)
+			log.Printf("Deleted collection '%s'\n", cl.Name)
 		}
 		return errors.Wrapf(err, "Couldn't delete collection '%s'.", cl.Name)
 	case MODIFY:
@@ -355,7 +356,7 @@ func (g Graph) Migrate(ctx context.Context, db driver.Database, _ map[string]int
 		}
 		err = aG.Remove(ctx)
 		if !e(err) {
-			fmt.Printf("Deleted graph '%s'\n", g.Name)
+			log.Printf("Deleted graph '%s'\n", g.Name)
 		}
 		return errors.Wrapf(err, "Couldn't remove graph %s", g.Name)
 	case MODIFY:
@@ -370,7 +371,7 @@ func (g Graph) Migrate(ctx context.Context, db driver.Database, _ map[string]int
 			for _, re := range g.RemoveEdges {
 				ec, _, err := aG.EdgeCollection(ctx, re)
 				if driver.IsNotFoundGeneral(err) {
-					fmt.Printf("Couldn't find edge collection '%s' to remove.\n", re)
+					log.Printf("Couldn't find edge collection '%s' to remove.\n", re)
 					continue
 				}
 
@@ -384,7 +385,7 @@ func (g Graph) Migrate(ctx context.Context, db driver.Database, _ map[string]int
 			for _, v := range g.RemoveVertices {
 				vc, err := aG.VertexCollection(ctx, v)
 				if driver.IsNotFoundGeneral(err) {
-					fmt.Printf("Couldn't find vertex '%s' to remove.", v)
+					log.Printf("Couldn't find vertex '%s' to remove.", v)
 				}
 				if err = vc.Remove(ctx); e(err) {
 					return errors.Wrapf(err, "Couldn't remove vertex collection '%s'", v)
@@ -662,7 +663,7 @@ func (a AQL) Migrate(ctx context.Context, db driver.Database, extras map[string]
 	defer func(cur driver.Cursor) {
 		err := cur.Close()
 		if err != nil {
-			fmt.Printf("could not close cursor")
+			log.Printf("could not close cursor")
 		}
 	}(cur)
 	return nil

--- a/impls_view.go
+++ b/impls_view.go
@@ -2,9 +2,9 @@ package arangomigo
 
 import (
 	"context"
-	"fmt"
 	"github.com/arangodb/go-driver"
 	"github.com/pkg/errors"
+	"log"
 	"reflect"
 )
 
@@ -16,7 +16,7 @@ func (searchView SearchView) Migrate(ctx context.Context, db driver.Database, ex
 		viewProperties := buildViewProperties(searchView)
 		_, err := db.CreateArangoSearchView(ctx, searchView.Name, &viewProperties)
 		if !e(err) {
-			fmt.Printf("Created view '%s'\n", searchView.Name)
+			log.Printf("Created view '%s'\n", searchView.Name)
 		}
 		return errors.Wrapf(err, "Couldn't create view '%s'", searchView.Name)
 	case DELETE:
@@ -26,7 +26,7 @@ func (searchView SearchView) Migrate(ctx context.Context, db driver.Database, ex
 		}
 		err = view.Remove(ctx)
 		if !e(err) {
-			fmt.Printf("Deleted view '%s'\n", searchView.Name)
+			log.Printf("Deleted view '%s'\n", searchView.Name)
 		}
 		return errors.Wrapf(err, "Couldn't delete view '%s'", searchView.Name)
 	case MODIFY:
@@ -41,7 +41,7 @@ func (searchView SearchView) Migrate(ctx context.Context, db driver.Database, ex
 		viewProperties := buildViewProperties(searchView)
 		err = aView.SetProperties(ctx, viewProperties)
 		if !e(err) {
-			fmt.Printf("Updated view '%s'\n", searchView.Name)
+			log.Printf("Updated view '%s'\n", searchView.Name)
 		}
 		return errors.Wrapf(err, "Couldn't update SearchView '%s'", searchView.Name)
 	}
@@ -83,7 +83,7 @@ func buildViewProperties(searchView SearchView) driver.ArangoSearchViewPropertie
 }
 
 func buildSortField(field SortField) driver.ArangoSearchPrimarySortEntry {
-	sortEntry := driver.ArangoSearchPrimarySortEntry{Field:field.Field}
+	sortEntry := driver.ArangoSearchPrimarySortEntry{Field: field.Field}
 	if field.Ascending != nil {
 		direction := driver.ArangoSearchSortDirectionDesc
 		if *field.Ascending {
@@ -169,7 +169,7 @@ func getFloat(unk interface{}) float64 {
 	fv := v.Convert(floatType)
 	return fv.Float()
 }
-func getInt(unk interface{}) int64  {
+func getInt(unk interface{}) int64 {
 	v := reflect.ValueOf(unk)
 	v = reflect.Indirect(v)
 	fv := v.Convert(intType)

--- a/migrations.go
+++ b/migrations.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -346,12 +347,12 @@ func loadFrom(path string) ([]Migration, error) {
 
 	var answer []Migration
 	for _, migration := range migrations {
-		fmt.Printf("file name: %s\n", migration)
+		log.Printf("file name: %s\n", migration)
 		as, err := toStruct(migration)
 		if err != nil {
 			return answer, err
 		}
-		fmt.Printf("The migration is %+v\n", as)
+		log.Printf("The migration is %+v\n", as)
 		answer = append(answer, as)
 	}
 


### PR DESCRIPTION
This is a minimal invasive change that replaces calls like `fmt.Print` with `log.Print`. I saw that you already use the native `log` package so I did not want to replace it with something else.

Now, users could decide if they want the output of this library or not:

```
previousOutput := log.Default().Writer()
log.Default().SetOutput(io.Discard)

arangomigo.DoSomething()

log.Default().SetOutput(previousOutput)
```

This addresses issue 26:  https://github.com/deusdat/arangomigo/issues/26