### PR TITLE
support stored-values for persistent indexes.

### DIFF
--- a/arangomigo_test.go
+++ b/arangomigo_test.go
@@ -71,7 +71,7 @@ func TestFullMigration(t *testing.T) {
 	// Can't really tell which indexes are available, just that recipes should have
 	// 7: 1 for the PK and 6 others.
 	idxs, err := recipes.Indexes(ctx)
-	assert.Equal(t, 7, len(idxs), "Recipes should have 7 indexes")
+	assert.Equal(t, 8, len(idxs), "Recipes should have 8 indexes")
 
 	// Make sure wait for sync sticks.
 	colprop, err := recipes.Properties(ctx)

--- a/migrations.go
+++ b/migrations.go
@@ -118,6 +118,7 @@ type PersistentIndex struct {
 	Unique       bool
 	Sparse       bool
 	InBackground bool
+	StoredValues []string
 }
 
 // TTLIndex creates a TTL index on the collections' fields.

--- a/testdata/complete/20.migration
+++ b/testdata/complete/20.migration
@@ -1,0 +1,10 @@
+type: persistentindex
+action: create
+fields:
+    - one
+collection: recipes
+unique: true
+sparse: true
+storedvalues:
+    - two
+    - three


### PR DESCRIPTION
Looking to support "storedValues" for persistent indexes, released in Arango 3.10 https://docs.arangodb.com/3.11/index-and-search/indexing/working-with-indexes/persistent-indexes/#storing-additional-values-in-indexes

https://github.com/deusdat/arangomigo/issues/28