### PR TITLE
Implements feature request #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This example creates a collection in the database named in the config file and s
   * shardkeys - list of fields to use for the shard key.
   * numberofshards - integer
   * allowuserkeys - boolean 
+  * keygeneratortype - string
   * volatile - boolean
   * compactable - boolean
   * waitforsync - boolean

--- a/arangomigo.go
+++ b/arangomigo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -59,6 +60,11 @@ func loadConf(confLoc string) (*Config, error) {
 		encased[fmt.Sprintf("${%s}", k)] = v
 	}
 	conf.Extras = encased
+
+	arangoUrl, exists := os.LookupEnv("ARANGO_URL")
+	if exists {
+		conf.Endpoints = []string{arangoUrl}
+	}
 	return &conf, nil
 }
 

--- a/arangomigo_test.go
+++ b/arangomigo_test.go
@@ -189,6 +189,50 @@ func TestSkipSSLVerify(t *testing.T) {
 	assert.NoError(t, err, "Unable to find the database")
 }
 
+func TestKeyGeneratorType(t *testing.T) {
+	configFile := "testdata/key_generator_type/config.yaml"
+	conf, err := loadConf(configFile)
+	if e(err) {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	cl, err := client(*conf)
+	if e(err) {
+		log.Fatal(err)
+	}
+
+	db, err := cl.Database(ctx, conf.Db)
+	if err == nil {
+		err := db.Remove(ctx)
+		if e(err) {
+			t.Fatal("Couldn't prepare for test")
+		}
+	}
+
+	_, err = cl.Database(ctx, conf.Db)
+	if !driver.IsNotFound(err) {
+		t.Fatal("Could not connect to the Database", err)
+	}
+
+	TriggerMigration(configFile)
+
+	// Look to see if everything was made properly.
+	db, err = cl.Database(ctx, conf.Db)
+	assert.NoError(t, err, "Unable to find the database")
+
+	recipes, err := db.Collection(ctx, "recipes")
+	assert.NoError(t, err, "Could not find recipes collection")
+
+	// Should find the custom recipe inserted by AQL.
+
+	collProps, err := recipes.Properties(ctx)
+	assert.NoError(t, err, "Could not read collection properties")
+
+	assert.Equal(t, "uuid", string(collProps.KeyOptions.Type), "Key generator should be uuid")
+}
+
 type recipe struct {
 	Name        string
 	WithEscaped string

--- a/impls.go
+++ b/impls.go
@@ -274,12 +274,18 @@ func (cl Collection) Migrate(ctx context.Context, db driver.Database, _ map[stri
 				options.Type = driver.CollectionTypeEdge
 			}
 		}
-		// Configures the user keys
-		ko := driver.CollectionKeyOptions{}
-		if cl.AllowUserKeys != nil {
-			ko.AllowUserKeysPtr = cl.AllowUserKeys
+
+		configuresKeyOptions := cl.AllowUserKeys != nil || cl.KeyGeneratorType != nil
+		if configuresKeyOptions {
+			ko := driver.CollectionKeyOptions{}
+			if cl.AllowUserKeys != nil {
+				ko.AllowUserKeysPtr = cl.AllowUserKeys
+			}
+			if cl.KeyGeneratorType != nil {
+				ko.Type = driver.KeyGeneratorType(*cl.KeyGeneratorType)
+			}
+			options.KeyOptions = &ko
 		}
-		options.KeyOptions = &ko
 
 		_, err := db.CreateCollection(ctx, cl.Name, &options)
 		if e(err) {

--- a/migrations.go
+++ b/migrations.go
@@ -74,14 +74,15 @@ type Database struct {
 type Collection struct {
 	Operation `yaml:",inline"`
 
-	ShardKeys      *[]string
-	JournalSize    *int
-	NumberOfShards *int
-	WaitForSync    *bool
-	AllowUserKeys  *bool
-	Volatile       *bool
-	Compactable    *bool
-	CollectionType string
+	ShardKeys        *[]string
+	JournalSize      *int
+	NumberOfShards   *int
+	WaitForSync      *bool
+	AllowUserKeys    *bool
+	KeyGeneratorType *string
+	Volatile         *bool
+	Compactable      *bool
+	CollectionType   string
 }
 
 // FullTextIndex defines how to build a full text index on a field

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose up --build --exit-code-from=test
+docker compose up --build --exit-code-from=test

--- a/testdata/key_generator_type/1_db.migration
+++ b/testdata/key_generator_type/1_db.migration
@@ -1,0 +1,6 @@
+type: database
+action: create
+name: MigoKeyGenerator
+allowed:
+  - username: ${patricksUser}
+    password: ${patricksPassword}

--- a/testdata/key_generator_type/2_collection.migration
+++ b/testdata/key_generator_type/2_collection.migration
@@ -1,0 +1,4 @@
+type: collection
+action: create
+name: recipes
+keygeneratortype: uuid

--- a/testdata/key_generator_type/config.yaml
+++ b/testdata/key_generator_type/config.yaml
@@ -1,0 +1,10 @@
+# Test configuration to make sure the system can create a collection with a custom key generator type
+endpoints:
+   - http://0.0.0.0:8529
+username: root
+password: simple
+migrationspath: testdata/key_generator_type
+db: MigoKeyGenerator
+extras:
+  {patricksUser: jdavenpo,
+   patricksPassword: L33t5uck3r5}


### PR DESCRIPTION
This PR contains three improvements:
1. Tests: The README states that test should be run with executing `./test.sh` but they were not running
   1. First commit fixes this issue. Problem was that the env variable "ARANGO_URL" wasn't read from some tests
   2. Second commit updates the "docker-compose" command to the new "docker compose" one
2. Adding support for configuration of key generator types for collection, which resolves #32 